### PR TITLE
Fix install package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Plugin for viewing streams located on the ant-media server. There is also a func
 ## Installation
 
 ```sh
-npm install --save videojs-webrtc-plugin
+npm install --save @antmedia/videojs-webrtc-plugin
 ```
 
 ## Usage


### PR DESCRIPTION
When trying to install the package like explained in README, I get an error:
```node
> pnpm add videojs-webrtc-plugin
 ERR_PNPM_MALFORMED_METADATA  Received malformed metadata for "videojs-webrtc-plugin"

This might mean that the package was unpublished from the registry
Progress: resolved 42, reused 42, downloaded 0, added 0
```

Searching for the npm package lead me to the new location: https://www.npmjs.com/package/@antmedia/videojs-webrtc-plugin

So I assume this is the new correct home

---

Beside that I assume the `package-lock.json` needs to be regenerated, but I didn't want to touch that from my side